### PR TITLE
[16.0][IMP] Improve _get_price performance by supporting batch computation.

### DIFF
--- a/product_get_price_helper/models/product_product.py
+++ b/product_get_price_helper/models/product_product.py
@@ -25,7 +25,7 @@ class ProductProduct(models.Model):
         :param company:     Optional.
         :param date:        Optional.
 
-        :returns: dict with the following keys:
+        :returns: A dictionary where keys are product IDs and values are dictionaries with:
 
             <value>                 The product unitary price
             <tax_included>          True if product taxes are included in <price>.
@@ -34,16 +34,12 @@ class ProductProduct(models.Model):
             <original_value>        The original price (before pricelist is applied).
             <discount>              The discounted percentage.
         """
-        self.ensure_one()
         AccountTax = self.env["account.tax"]
-        # Apply company
-        product = self.with_company(company) if company else self
+        DecimalPrecision = self.env["decimal.precision"]
+        price_dp = DecimalPrecision.precision_get("Product Price")
+        discount_dp = DecimalPrecision.precision_get("Discount")
+
         company = company or self.env.company
-        # Always filter taxes by the company
-        taxes = product.taxes_id.filtered(lambda tax: tax.company_id == company)
-        # Apply fiscal position
-        taxes = fposition.map_tax(taxes) if fposition else taxes
-        # Set context. Some of the methods used here depend on these values
         product_context = dict(
             self.env.context,
             quantity=qty,
@@ -51,55 +47,75 @@ class ProductProduct(models.Model):
             fiscal_position=fposition,
             date=date,
         )
-        product = product.with_context(**product_context)
-        pricelist = pricelist.with_context(**product_context) if pricelist else None
-        price_unit = (
-            pricelist._get_product_price(product, qty, date=date)
-            if pricelist
-            else product.lst_price
-        )
-        price_unit = AccountTax._fix_tax_included_price_company(
-            price_unit, product.taxes_id, taxes, company
-        )
-        price_dp = self.env["decimal.precision"].precision_get("Product Price")
-        price_unit = float_round(price_unit, price_dp)
-        res = {
-            "value": price_unit,
-            "tax_included": any(tax.price_include for tax in taxes),
-            # Default values in case price.discount_policy != "without_discount"
-            "original_value": price_unit,
-            "discount": 0.0,
-        }
-        # Handle pricelists.discount_policy == "without_discount"
-        if pricelist and pricelist.discount_policy == "without_discount":
-            # Get the price rule
-            price_unit, _ = pricelist._get_product_price_rule(product, qty, date=date)
-            # Get the price before applying the pricelist
-            original_price_unit = product.lst_price
-            price_dp = self.env["decimal.precision"].precision_get("Product Price")
-            # Compute discount
-            if not float_is_zero(
-                original_price_unit, precision_digits=price_dp
-            ) and float_compare(
-                original_price_unit, price_unit, precision_digits=price_dp
-            ):
-                discount = (
-                    (original_price_unit - price_unit) / original_price_unit * 100
-                )
-                # Apply the right precision on discount
-                discount_dp = self.env["decimal.precision"].precision_get("Discount")
-                discount = float_round(discount, discount_dp)
+
+        # Prefetch related fields to avoid N+1
+        self = self.with_company(company).with_context(**product_context)
+        self.read(["lst_price", "taxes_id"])
+
+        # Apply fiscal position + filter by company
+        taxes_map = {}
+        for product in self:
+            taxes = product.taxes_id.filtered(lambda tax: tax.company_id == company)
+            if fposition:
+                taxes = fposition.map_tax(taxes)
+            taxes_map[product.id] = taxes
+
+        result = {}
+
+        price_unit_list = []
+        if pricelist:
+            price_unit_list = pricelist.with_context(
+                **product_context
+            )._compute_price_rule(self, qty, date=date)
+
+        for product in self:
+            taxes = taxes_map[product.id]
+            tax_included = any(t.price_include for t in taxes)
+
+            if price_unit_list:
+                price_unit = price_unit_list[product.id][0]
             else:
-                discount = 0.00
-            # Compute prices
-            original_price_unit = AccountTax._fix_tax_included_price_company(
-                original_price_unit, product.taxes_id, taxes, company
+                price_unit = product.lst_price
+
+            price_unit = AccountTax._fix_tax_included_price_company(
+                price_unit, product.taxes_id, taxes, company
             )
-            original_price_unit = float_round(original_price_unit, price_dp)
-            res.update(
-                {
-                    "original_value": original_price_unit,
-                    "discount": discount,
-                }
-            )
-        return res
+            price_unit = float_round(price_unit, price_dp)
+
+            res = {
+                "value": price_unit,
+                "tax_included": tax_included,
+                "original_value": price_unit,
+                "discount": 0.0,
+            }
+
+            # Handle pricelists with "without_discount" policy
+            if pricelist and pricelist.discount_policy == "without_discount":
+                price_unit = price_unit_list[product.id][0]
+                original_price = product.lst_price
+
+                if not float_is_zero(
+                    original_price, precision_digits=price_dp
+                ) and float_compare(
+                    original_price, price_unit, precision_digits=price_dp
+                ):
+                    discount = (original_price - price_unit) / original_price * 100
+                    discount = float_round(discount, discount_dp)
+                else:
+                    discount = 0.0
+
+                original_price_fixed = AccountTax._fix_tax_included_price_company(
+                    original_price, product.taxes_id, taxes, company
+                )
+                original_price_fixed = float_round(original_price_fixed, price_dp)
+
+                res.update(
+                    {
+                        "original_value": original_price_fixed,
+                        "discount": discount,
+                    }
+                )
+
+            result[product.id] = res
+
+        return result

--- a/product_get_price_helper/tests/test_product.py
+++ b/product_get_price_helper/tests/test_product.py
@@ -19,7 +19,7 @@ class ProductCase(TransactionCase):
 
     def test_product_simple_get_price(self):
         self.assertEqual(
-            self.variant._get_price(),
+            self.variant._get_price()[self.variant.id],
             {
                 "discount": 0.0,
                 "original_value": 750.0,
@@ -42,7 +42,10 @@ class ProductCase(TransactionCase):
         )
         self.variant.list_price = 423.4
         self.assertEqual(
-            self.variant._get_price(pricelist=self.base_pricelist)["value"], 211.70
+            self.variant._get_price(pricelist=self.base_pricelist)[self.variant.id][
+                "value"
+            ],
+            211.70,
         )
 
     def test_product_get_price(self):
@@ -52,7 +55,7 @@ class ProductCase(TransactionCase):
             pricelist=self.base_pricelist, fposition=fiscal_position_fr
         )
         self.assertDictEqual(
-            price,
+            price[self.variant.id],
             {
                 "discount": 0.0,
                 "original_value": 750.0,
@@ -66,7 +69,7 @@ class ProductCase(TransactionCase):
             pricelist=promotion_price_list, fposition=fiscal_position_fr
         )
         self.assertDictEqual(
-            price,
+            price[self.variant.id],
             {
                 "discount": 0.0,
                 "original_value": 600.0,
@@ -83,7 +86,7 @@ class ProductCase(TransactionCase):
             pricelist=self.base_pricelist, fposition=tax_exclude_fiscal_position
         )
         self.assertDictEqual(
-            price,
+            price[self.variant.id],
             {
                 "discount": 0.0,
                 "original_value": 652.17,
@@ -95,7 +98,7 @@ class ProductCase(TransactionCase):
             pricelist=promotion_price_list, fposition=tax_exclude_fiscal_position
         )
         self.assertDictEqual(
-            price,
+            price[self.variant.id],
             {
                 "discount": 0.0,
                 "original_value": 521.74,
@@ -120,7 +123,7 @@ class ProductCase(TransactionCase):
             pricelist=self.base_pricelist, fposition=fiscal_position_fr
         )
         self.assertDictEqual(
-            price,
+            price[self.variant.id],
             {
                 "discount": 0.0,
                 "original_value": 0.0,
@@ -150,7 +153,7 @@ class ProductCase(TransactionCase):
             qty=1.0, pricelist=pricelist, fposition=fposition
         )
         self.assertDictEqual(
-            price,
+            price[self.variant.id],
             {
                 "discount": 0.0,
                 "original_value": 750.0,
@@ -164,7 +167,7 @@ class ProductCase(TransactionCase):
             qty=10.0, pricelist=pricelist, fposition=fposition
         )
         self.assertDictEqual(
-            price,
+            price[self.variant.id],
             {
                 "discount": 0.0,
                 "original_value": 600.0,
@@ -184,7 +187,7 @@ class ProductCase(TransactionCase):
             pricelist=self.base_pricelist, fposition=fiscal_position_fr
         )
         self.assertDictEqual(
-            price,
+            price[self.variant.id],
             {
                 "tax_included": True,
                 "value": 750.0,
@@ -200,7 +203,7 @@ class ProductCase(TransactionCase):
             pricelist=promotion_price_list, fposition=fiscal_position_fr
         )
         self.assertDictEqual(
-            price,
+            price[self.variant.id],
             {
                 "tax_included": True,
                 "value": 600.0,
@@ -219,7 +222,7 @@ class ProductCase(TransactionCase):
             pricelist=self.base_pricelist, fposition=tax_exclude_fiscal_position
         )
         self.assertDictEqual(
-            price,
+            price[self.variant.id],
             {
                 "tax_included": False,
                 "value": 652.17,
@@ -231,7 +234,7 @@ class ProductCase(TransactionCase):
             pricelist=promotion_price_list, fposition=tax_exclude_fiscal_position
         )
         self.assertDictEqual(
-            price,
+            price[self.variant.id],
             {
                 "tax_included": False,
                 "value": 521.74,


### PR DESCRIPTION
### Result
Based on the `TODO` of the `BSALLO-2116` card, we get the following parameters:
- Step 1: get the server action trick ready and time a call with a list of about 100 products
  - Time duration: **0.35336947441101074** seconds
- Step 2: fix the implementation of _get_price() to have it run efficiently on multiple products (**This PR**)
- Step 3: use the server action trick again to time the call on the same set of products as in step 1 and report back the improvement
  -  Time duration: **0.033194780349731445** seconds

==> **Execution time is expected to improve by ~10x with this change.**

### Notes:
- The test data is newly created based on the local `alloboissons` project source. In practice it will take longer to execute due to the complexity of the data.
- The main cause of performance problem is **N+1 queries** (Fixed in **product_get_price_helper/models/product_product.py#53**). If we remove it, time duration will be **0.32950735092163086** seconds.

